### PR TITLE
1 year ago a release for testnet-v2 was made. This should have been committed as well.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as builder
 
 #Snapshots 2018-01-10-23:14:45
-ENV HORIZON_VERSION=f0514b102943b0d97c937baa0a46d9bb5dc26269
+ENV HORIZON_VERSION=3597e88a2cfc00e8d6de538b6a8bc31c6fa31ace
 
 RUN apk add --no-cache git gcc linux-headers musl-dev glide mercurial \
     && mkdir -p /go/src/github.com/stellar/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as builder
 
 #Snapshots 2018-01-10-23:14:45
-ENV HORIZON_VERSION=bb828ecd47ffc11651722374b78b63b8674cd8b8
+ENV HORIZON_VERSION=f0514b102943b0d97c937baa0a46d9bb5dc26269
 
 RUN apk add --no-cache git gcc linux-headers musl-dev glide mercurial \
     && mkdir -p /go/src/github.com/stellar/ \


### PR DESCRIPTION
In that 1 year period packages from the go repo had failed. The fix for the that is here: https://github.com/KinesisNetwork/go/pull/5
